### PR TITLE
fix link to COS in readme and various other cleanups

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .git/
-Dockerfile
 README.*
 assets/data
 .gitignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: python
 python:
-- 3.6
+  - 3.6
 services:
-- docker
+  - docker
 install:
-- docker build -t max-audio-sample-generator .
-- docker run -it -d -p 5000:5000 max-audio-sample-generator
-- sleep 10
+  - docker build -t max-audio-sample-generator .
+  - docker run -it -d -p 5000:5000 max-audio-sample-generator
+  - pip install pytest requests scipy numpy
 before_script:
-- pip install pytest requests scipy numpy
+  - flake8 . --max-line-length=127
+  - sleep 30
 script:
-- pytest tests/test.py
+  - pytest tests/test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 install:
   - docker build -t max-audio-sample-generator .
   - docker run -it -d -p 5000:5000 max-audio-sample-generator
-  - pip install pytest requests scipy numpy
+  - pip install pytest requests scipy numpy flake8
 before_script:
   - flake8 . --max-line-length=127
   - sleep 30

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM codait/max-base:v1.1.0
+FROM codait/max-base:v1.1.1
 
 # Fill in these with a link to the bucket containing the model and the model file name
-ARG model_bucket=http://max-assets.s3-api.us-geo.objectstorage.softlayer.net/max-audio-sample-generator
+ARG model_bucket=http://max-assets.s3.us.cloud-object-storage.appdomain.cloud/max-audio-sample-generator
 ARG model_files=models.tar.gz
 
 # Get model archive and unzip it to assets folder
@@ -12,7 +12,9 @@ COPY requirements.txt /workspace
 RUN pip install -r requirements.txt
 
 COPY . /workspace
-RUN md5sum -c md5sums.txt  # check file integrity
+
+# check file integrity
+RUN md5sum -c md5sums.txt
 
 EXPOSE 5000
 

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2019 IBM Corporation
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,21 @@
-[![Build Status](https://travis-ci.com/IBM/MAX-Audio-Sample-Generator.svg?branch=master)](https://travis-ci.com/IBM/MAX-Audio-Sample-Generator) [![Website Status](https://img.shields.io/website/http/max-audio-sample-generator.max.us-south.containers.appdomain.cloud/swagger.json.svg?label=api+demo)](http://max-audio-sample-generator.max.us-south.containers.appdomain.cloud/)
+[![Build Status](https://travis-ci.com/IBM/MAX-Audio-Sample-Generator.svg?branch=master)](https://travis-ci.com/IBM/MAX-Audio-Sample-Generator)
+[![Website Status](https://img.shields.io/website/http/max-audio-sample-generator.max.us-south.containers.appdomain.cloud/swagger.json.svg?label=api+demo)](http://max-audio-sample-generator.max.us-south.containers.appdomain.cloud/)
 
 # IBM Developer Model Asset Exchange: Audio Sample Generator
 
-This repository contains code to instantiate and deploy an audio generation model. The model generates short samples based on an existing dataset of audio clips. It maps the sample space of the input data and generates audio clips that are "inbetween" or "combinations" of the dominant features of the sounds. The model architecture is a generative adversarial neural network, trained by the [IBM CODAIT Team](codait.org) on lo-fi instrumental music tracks from the [Free Music Archive](http://freemusicarchive.org) and short spoken commands from the [Speech Commands Dataset](https://ai.googleblog.com/2017/08/launching-speech-commands-dataset.html). The model can generate 1.5 second audio samples of the words `up`, `down`, `left`, `right`, `stop`, `go`, as well as lo-fi instrumental music.
+This repository contains code to instantiate and deploy an audio generation model. The model generates short samples
+based on an existing dataset of audio clips. It maps the sample space of the input data and generates audio clips that
+are "inbetween" or "combinations" of the dominant features of the sounds. The model architecture is a generative
+adversarial neural network, trained by the [IBM CODAIT Team](codait.org) on lo-fi instrumental music tracks from the
+[Free Music Archive](http://freemusicarchive.org) and short spoken commands from the
+[Speech Commands Dataset](https://ai.googleblog.com/2017/08/launching-speech-commands-dataset.html). The model can
+generate 1.5 second audio samples of the words `up`, `down`, `left`, `right`, `stop`, `go`, as well as lo-fi
+instrumental music.
 
-The model is based on the [WaveGAN Model](https://github.com/chrisdonahue/wavegan). The model files are hosted on [IBM Cloud Object Storage](http://max-assets.s3-api.us-geo.objectstorage.softlayer.net/max-audio-sample-generator/wavegan.tar.gz). The code in this repository deploys the model as a web service in a Docker container. This repository was developed as part of the [IBM Code Model Asset Exchange](https://developer.ibm.com/code/exchanges/models/).
+The model is based on the [WaveGAN Model](https://github.com/chrisdonahue/wavegan). The model files are hosted on
+[IBM Cloud Object Storage](http://max-assets.s3.us.cloud-object-storage.appdomain.cloud/max-audio-sample-generator/models.tar.gz).
+The code in this repository deploys the model as a web service in a Docker container. This repository was developed as
+part of the [IBM Code Model Asset Exchange](https://developer.ibm.com/code/exchanges/models/).
 
 ## Model Metadata
 | Domain | Application | Industry  | Framework | Training Data | Input Data Format |
@@ -45,7 +56,8 @@ To run the docker image, which automatically starts the model serving API, run:
 $ docker run -it -p 5000:5000 codait/max-audio-sample-generator
 ```
 
-This will pull a pre-built image from Docker Hub (or use an existing image if already cached locally) and run it. If you'd rather checkout and build the model locally you can follow the [run locally](#run-locally) steps below.
+This will pull a pre-built image from Docker Hub (or use an existing image if already cached locally) and run it. If
+you'd rather checkout and build the model locally you can follow the [run locally](#run-locally) steps below.
 
 ## Deploy on Kubernetes
 
@@ -87,7 +99,9 @@ To build the docker image locally, run:
 $ docker build -t max-audio-sample-generator .
 ```
 
-All required model assets will be downloaded during the build process. _Note_ the model files for all audio types are extremely large and the download will take a while. _Note_ that currently this docker image is CPU only (we will add support for GPU images later).
+All required model assets will be downloaded during the build process. _Note_ the model files for all audio types are
+extremely large and the download will take a while. _Note_ that currently this docker image is CPU only (we will add
+support for GPU images later).
 
 ### 2. Deploy the Model
 
@@ -99,12 +113,15 @@ $ docker run -it -p 5000:5000 max-audio-sample-generator
 
 ### 3. Use the Model
 
-The API server automatically generates an interactive Swagger documentation page. Go to `http://localhost:5000` to load it. From there you can explore the API and also create test requests.
-Use the `model/predict` endpoint to generate an audio clip from one of the provided models, which can then be played in the Swagger UI.
+The API server automatically generates an interactive Swagger documentation page. Go to `http://localhost:5000` to load
+it. From there you can explore the API and also create test requests.
+Use the `model/predict` endpoint to generate an audio clip from one of the provided models, which can then be played in
+the Swagger UI.
 
 ![Swagger UI Screenshot](docs/swagger-screenshot.png)
 
-You can also test it on the command line. The `model/predict` endpoint returns a bytestream of the audio, which you can then direct into a file using `>`; for example:
+You can also test it on the command line. The `model/predict` endpoint returns a bytestream of the audio, which you can
+then direct into a file using `>`; for example:
 
 ```
  $ curl -X GET 'http://localhost:5000/model/predict' -H 'accept: audio/wav' > result.wav
@@ -120,7 +137,8 @@ $ curl -X GET 'http://localhost:5000/model/predict?model=stop' -H 'accept: audio
 
 ### 4. Development
 
-To run the Flask API app in debug mode, edit `config.py` to set `DEBUG = True` under the application settings. You will then need to rebuild the docker image (see [step 1](#1-build-the-model)).
+To run the Flask API app in debug mode, edit `config.py` to set `DEBUG = True` under the application settings. You will
+then need to rebuild the docker image (see [step 1](#1-build-the-model)).
 
 ### 5. Cleanup
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 This repository contains code to instantiate and deploy an audio generation model. The model generates short samples
 based on an existing dataset of audio clips. It maps the sample space of the input data and generates audio clips that
 are "inbetween" or "combinations" of the dominant features of the sounds. The model architecture is a generative
-adversarial neural network, trained by the [IBM CODAIT Team](codait.org) on lo-fi instrumental music tracks from the
+adversarial neural network, trained by the [IBM CODAIT Team](http://codait.org) on lo-fi instrumental music tracks from the
 [Free Music Archive](http://freemusicarchive.org) and short spoken commands from the
 [Speech Commands Dataset](https://ai.googleblog.com/2017/08/launching-speech-commands-dataset.html). The model can
 generate 1.5 second audio samples of the words `up`, `down`, `left`, `right`, `stop`, `go`, as well as lo-fi

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,2 +1,2 @@
-from .metadata import ModelMetadataAPI
-from .predict import ModelPredictAPI
+from .metadata import ModelMetadataAPI  # noqa
+from .predict import ModelPredictAPI  # noqa

--- a/api/metadata.py
+++ b/api/metadata.py
@@ -1,6 +1,6 @@
 from core.model import ModelWrapper
-
 from maxfw.core import MAX_API, MetadataAPI, METADATA_SCHEMA
+
 
 class ModelMetadataAPI(MetadataAPI):
 

--- a/api/predict.py
+++ b/api/predict.py
@@ -1,17 +1,11 @@
 from core.model import ModelWrapper
-
-from maxfw.core import MAX_API, PredictAPI, MetadataAPI
-
-from librosa.output import write_wav
+from maxfw.core import MAX_API, PredictAPI
 from flask import make_response
-from flask_restplus import Namespace, Resource, fields
-from werkzeug.datastructures import FileStorage
-
-from config import MODEL_META_DATA, DEFAULT_MODEL, MODELS
+from config import DEFAULT_MODEL, MODELS
 
 # Set up parser for predict request (http://flask-restplus.readthedocs.io/en/stable/parsing.html)
 input_parser = MAX_API.parser()
-input_parser.add_argument('model',type=str, default=DEFAULT_MODEL, choices=MODELS)
+input_parser.add_argument('model', type=str, default=DEFAULT_MODEL, choices=MODELS)
 
 
 class ModelPredictAPI(PredictAPI):
@@ -24,7 +18,7 @@ class ModelPredictAPI(PredictAPI):
         """Make a prediction given input data"""
         args = input_parser.parse_args()
         model = args['model']
-        preds = self.model_wrapper.predict(model)
+        _ = self.model_wrapper.predict(model)
 
         response = make_response(open('output.wav', 'rb').read())
         response.headers.set('Content-Type', 'audio/wav')

--- a/config.py
+++ b/config.py
@@ -14,11 +14,11 @@ API_VERSION = '1.1.0'
 # default model
 MODEL_NAME = 'wavegan'
 DEFAULT_MODEL_PATH = 'assets/models'
-MODEL_LICENSE =  'Apache2'
+MODEL_LICENSE = 'Apache2'
 
 # generator model options and default
 DEFAULT_MODEL = 'lofi-instrumentals'
-MODELS = ['lofi-instrumentals','up','down','left','right','stop','go']
+MODELS = ['lofi-instrumentals', 'up', 'down', 'left', 'right', 'stop', 'go']
 INPUT_TENSOR = 'z:0'
 OUTPUT_TENSOR = 'G_z:0'
 

--- a/core/model.py
+++ b/core/model.py
@@ -10,16 +10,17 @@ logging.basicConfig()
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
+
 class SingleModelWrapper(object):
 
     def __init__(self, model, path):
         self.graph = tf.Graph()
         with self.graph.as_default():
-            self.sess = tf.Session(graph = self.graph)
+            self.sess = tf.Session(graph=self.graph)
             saver = tf.train.import_meta_graph('{}/train_{}/infer/infer.meta'.format(path, model))
             saver.restore(self.sess, tf.train.latest_checkpoint('{}/train_{}/'.format(path, model)))
             self.input = self.graph.get_tensor_by_name(INPUT_TENSOR)
-            self.output  = self.graph.get_tensor_by_name(OUTPUT_TENSOR)
+            self.output = self.graph.get_tensor_by_name(OUTPUT_TENSOR)
 
     def predict(self):
         # Create 50 random latent vectors z
@@ -30,7 +31,7 @@ class SingleModelWrapper(object):
 
 
 class ModelWrapper(MAXModelWrapper):
-    
+
     MODEL_META_DATA = model_meta
 
     def __init__(self, path=DEFAULT_MODEL_PATH):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 tensorflow==1.5.0
-librosa
-numpy
+librosa==0.6.3
+numpy==1.16.2


### PR DESCRIPTION
- Removed `Dockerfile` from `.dockerignore`
- Added `flake8` testing
- Cleaned up code so `flake8` passes
- Use latest `max-base`
- Use new IBM COS API URL
- Update COS URL in `README`
- Added `Copyright 2019 IBM Corporation` to `LICENSE`
- Set specific version numbers in `requirements.txt`

resolves #10 