### PR TITLE
Avoid creating a Docker layer containing the compressed model file.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,11 @@ FROM codait/max-base:v1.1.1
 ARG model_bucket=http://max-assets.s3.us.cloud-object-storage.appdomain.cloud/max-audio-sample-generator
 ARG model_files=models.tar.gz
 
+WORKDIR /workspace
+
 # Get model archive and unzip it to assets folder
-RUN wget -nv ${model_bucket}/${model_files} --output-document=/workspace/assets/${model_files} --show-progress --progress=bar:force:noscroll
-RUN tar -x -C assets/ -f assets/${model_files} -v && rm assets/${model_files}
+RUN wget -nv ${model_bucket}/${model_files} --output-document=assets/${model_files} --show-progress --progress=bar:force:noscroll && \
+  tar -x -C assets/ -f assets/${model_files} -v && rm assets/${model_files}
 
 COPY requirements.txt /workspace
 RUN pip install -r requirements.txt


### PR DESCRIPTION
Download and delete the compressed model file in the same layer to avoid an (often oversized) additional Docker layer.