### PR TITLE
Fix play button in Firefox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM codait/max-base:v1.1.1
+FROM codait/max-base:v1.1.3
 
 # Fill in these with a link to the bucket containing the model and the model file name
-ARG model_bucket=http://max-assets.s3.us.cloud-object-storage.appdomain.cloud/max-audio-sample-generator
+ARG model_bucket=https://max-assets.s3.us.cloud-object-storage.appdomain.cloud/max-audio-sample-generator
 ARG model_files=models.tar.gz
 
 WORKDIR /workspace

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ generate 1.5 second audio samples of the words `up`, `down`, `left`, `right`, `s
 instrumental music.
 
 The model is based on the [WaveGAN Model](https://github.com/chrisdonahue/wavegan). The model files are hosted on
-[IBM Cloud Object Storage](http://max-assets.s3.us.cloud-object-storage.appdomain.cloud/max-audio-sample-generator/models.tar.gz).
+[IBM Cloud Object Storage](https://max-assets.s3.us.cloud-object-storage.appdomain.cloud/max-audio-sample-generator/models.tar.gz).
 The code in this repository deploys the model as a web service in a Docker container. This repository was developed as
 part of the [IBM Code Model Asset Exchange](https://developer.ibm.com/code/exchanges/models/).
 

--- a/api/predict.py
+++ b/api/predict.py
@@ -1,5 +1,5 @@
 from core.model import ModelWrapper
-from maxfw.core import MAX_API, PredictAPI
+from maxfw.core import MAX_API, CustomMAXAPI
 from flask import make_response
 from config import DEFAULT_MODEL, MODELS
 
@@ -8,14 +8,14 @@ input_parser = MAX_API.parser()
 input_parser.add_argument('model', type=str, default=DEFAULT_MODEL, choices=MODELS)
 
 
-class ModelPredictAPI(PredictAPI):
+class ModelPredictAPI(CustomMAXAPI):
 
     model_wrapper = ModelWrapper()
 
     @MAX_API.doc(produces=['audio/wav'])
     @MAX_API.expect(input_parser)
     def get(self):
-        """Make a prediction given input data"""
+        """Generate audio file"""
         args = input_parser.parse_args()
         model = args['model']
         _ = self.model_wrapper.predict(model)

--- a/core/model.py
+++ b/core/model.py
@@ -47,7 +47,7 @@ class ModelWrapper(MAXModelWrapper):
         preds = self.models[model].predict()
 
         # convert audio to 16 bit so that it can play in firefox
-        audio_data = np.round(preds[0] * 32767)
+        audio_data = np.round(preds[0] * np.iinfo(np.int16).max)
         audio_data = audio_data.astype(np.int16)
 
         scipy.io.wavfile.write("output.wav", 16000, audio_data)

--- a/core/model.py
+++ b/core/model.py
@@ -1,10 +1,9 @@
 from maxfw.model import MAXModelWrapper
-
 import tensorflow as tf
 import numpy as np
 import logging
 from config import DEFAULT_MODEL_PATH, MODELS, INPUT_TENSOR, OUTPUT_TENSOR, MODEL_META_DATA as model_meta
-from librosa.output import write_wav
+import scipy.io.wavfile
 
 logging.basicConfig()
 logger = logging.getLogger()
@@ -46,6 +45,11 @@ class ModelWrapper(MAXModelWrapper):
     def _predict(self, model):
         logger.info('Generating audio from model: {}'.format(model))
         preds = self.models[model].predict()
-        write_wav('output.wav', preds[0], 16000)
+
+        # convert audio to 16 bit so that it can play in firefox
+        audio_data = np.round(preds[0] * 32767)
+        audio_data = audio_data.astype(np.int16)
+
+        scipy.io.wavfile.write("output.wav", 16000, audio_data)
         wav_bytes = open('output.wav')
         return wav_bytes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 tensorflow==1.12.2
-librosa==0.6.3
 numpy==1.16.2
+scipy==1.3.0

--- a/tests/test.py
+++ b/tests/test.py
@@ -58,8 +58,7 @@ def test_predict():
         assert numpy.max(audio[1]) > 0
         assert numpy.min(audio[1]) < 0
 
-        audio_range = numpy.max(audio[1]) - numpy.min(audio[1])
-        assert audio_range > 0  # this model has a very small range, the model should be improved in the future
+        assert numpy.max(audio[1]) > numpy.min(audio[1])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
resolves #1

- use latest max-base
- change cos links to https
- use `CustomMAXAPI` instead of `PredictAPI` so that is not an empty endpoint (see http://max-audio-sample-generator.max.us-south.containers.appdomain.cloud/)
- use `scipy` instead of `librosa`
- send audio files to browser in 16 bit instead of 32 bit so that Firefox can play it